### PR TITLE
chore: add eslint and prettier config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['next/core-web-vitals', 'plugin:prettier/recommended'],
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals"]
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
+    "format": "prettier --write .",
     "test": "jest"
   },
   "dependencies": {
@@ -21,6 +22,9 @@
     "typescript": "5.4.2",
     "eslint": "8.56.0",
     "eslint-config-next": "14.2.5",
-    "jest": "29.7.0"
+    "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-prettier": "5.1.3",
+    "jest": "29.7.0",
+    "prettier": "3.3.2"
   }
 }


### PR DESCRIPTION
## Summary
- add shared ESLint configuration file
- define Prettier formatting rules
- expose lint and format npm scripts

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-prettier" due to install errors)*
- `npm run format`
- `npm install` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_6892053b6b3083289512efb57be595bc